### PR TITLE
Do not attempt to create file in obsolete RAMdisk mountpoint

### DIFF
--- a/banner.sh
+++ b/banner.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/dash
 
 # update prep_info as suggested by @MichaIng
-cat << _EOF_ > /boot/dietpi/.prep_info
+cat << '_EOF_' > /boot/dietpi/.prep_info
 yumiris
-DietPi for WMware
+DietPi for VMware
 _EOF_

--- a/banner.sh
+++ b/banner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # update prep_info as suggested by @MichaIng
-cat << _EOF_ > /{DietPi,boot}/dietpi/.prep_info
+cat << _EOF_ > /boot/dietpi/.prep_info
 yumiris
 DietPi for WMware
 _EOF_


### PR DESCRIPTION
With DietPi v6.29, DietPi-RAMdisk has been removed, hence the /DietPi path is now obsolete. It is kept as symlink on existing systems for backwards compatibility, but new images do not have it anymore. Hence, writing files only to the disk location /boot/dietpi/ is sufficient now.

Relevant part of the changelog: https://github.com/MichaIng/DietPi/blob/6c30f66ee0bf8dce0620bbe3dfa907a8e7ed0f24/CHANGELOG.txt#L50

Signed-off-by: MichaIng <micha@dietpi.com>